### PR TITLE
add reset as hash method to replace the current node

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,10 +244,23 @@ var updated = store.get()
 console.log( updated ); //{a: 'hola'}
 ```
 
+#### reset( newNode )
+Reset/replaces the node with the newNode
+
+```js
+var store = new Freezer({ foobar: {a: 'a', b: 'b', c: [0, 1, 2] } });
+
+var newfoobar = { foo: 'bar', bar: 'foo' };
+
+var reset = data.foobar.reset(newfoobar);
+
+console.log( reset ); //{ foo: 'bar', bar: 'foo' }
+```
+
 ## Array methods
 Array nodes have modified versions of the `push`, `pop`, `unshift`, `shift` and `splice` methods that update the cursor and return the new node, instead of updating the immutable array node ( that would be impossible ).
 ```js
-var store = new Cursor({ arr: [0,1,2,3,4] });
+var store = new Freezer({ arr: [0,1,2,3,4] });
 
 store.get().arr
     .push( 5 ) // [0,1,2,3,4,5]
@@ -260,12 +273,26 @@ store.get().arr
 
 Array nodes also have the `append` and `prepend` methods to batch insert elements at the begining or the end of the array.
 ```js
-var store = new Cursor({ arr: [2] });
+var store = new Freezer({ arr: [2] });
 
 store.get().arr
     .prepend([0,1]) // [0,1,2]
     .append([3,4]) // [0,1,2,3,4]
 ;
+```
+
+Note that arrays do not have a `reset` method available, in case you need to 
+
+##### remove all elements of an array use
+```js
+var store = new Freezer({ arr: [0, 1, 2, 3, 4] });
+store.get().arr.splice(0); // returns []
+```
+##### replace the entire contents of an array use
+```js
+var store = new Freezer({ arr: [0, 1, 2, 3, 4] });
+var replacement = [10, 20, 30, 40];
+store.get().arr.splice(0).append(replacement); // returns [10, 20, 30, 40]
 ```
 
 ## Events

--- a/src/frozen.js
+++ b/src/frozen.js
@@ -82,7 +82,7 @@ var Frozen = {
 		return frozen;
 	},
 
-	replace: function( node, attrs ){
+	merge: function( node, attrs ){
 		var me = this,
 			frozen = this.copyMeta( node ),
 			notify = node.__.notify,

--- a/src/frozen.js
+++ b/src/frozen.js
@@ -135,7 +135,31 @@ var Frozen = {
 
 		return frozen;
 	},
+	replaceself: function( node, attrs ) {
+		var me = this,
+			frozen = this.copyMeta( node ),
+			notify = node.__.notify,
+			val, cons, key
+		;
+		for( key in attrs ) {
+			val = attrs[ key ];
+			cons = val && val.constructor;
 
+			if( cons == Array || cons == Object )
+				val = me.freeze( val, notify );
+
+			if( val && val.__ )
+				me.addParent( val, frozen );
+
+			frozen[ key ] = val;
+		}
+
+		Object.freeze( frozen );
+
+		this.refreshParents( node, frozen );
+
+		return frozen;
+	},
 	remove: function( node, attrs ){
 		var me = this,
 			frozen = this.copyMeta( node ),

--- a/src/mixins.js
+++ b/src/mixins.js
@@ -121,7 +121,12 @@ Hash: Object.create( Object.prototype, createNE( Utils.extend({
 		if( filtered.length )
 			return this.__.notify( 'remove', this, filtered );
 		return this;
+	},
+
+	reset: function( attrs ) {
+		return this.__.notify( 'replaceself', this, attrs );
 	}
+
 }, commonMethods))),
 
 List: FrozenArray,

--- a/src/mixins.js
+++ b/src/mixins.js
@@ -33,7 +33,7 @@ var commonMethods = {
 			attrs[ attr ] = value;
 		}
 
-		return this.__.notify( 'replace', this, attrs );
+		return this.__.notify( 'merge', this, attrs );
 	},
 
 	getListener: function(){

--- a/tests/array-spec.js
+++ b/tests/array-spec.js
@@ -123,6 +123,16 @@ describe("Freezer array test", function(){
 		assert.deepEqual( concat, ['A','B','C','D'] );
 	});
 
+	it( "Remove all from array", function(){
+		var removedArr = data.c.splice(0);
+		assert.deepEqual( removedArr, [] );
+
+		var updated = freezer.getData();
+		assert.deepEqual( updated.c, [] );
+
+		assert.deepEqual(data.c.splice(0, Number.MAX_VALUE), []);
+	});
+
 	it( "#toJS", function(){
 		assert.deepEqual( data.c.toJS(), example.c );
 	});

--- a/tests/array-spec.js
+++ b/tests/array-spec.js
@@ -132,6 +132,13 @@ describe("Freezer array test", function(){
 
 		assert.deepEqual(data.c.splice(0, Number.MAX_VALUE), []);
 	});
+	it( "Replace all from array", function(){
+		var replacement = [10, 20, 30, 40];
+		var removedArr = data.c.splice(0)
+			.append(replacement);
+
+		assert.deepEqual( removedArr, replacement );
+	});
 
 	it( "#toJS", function(){
 		assert.deepEqual( data.c.toJS(), example.c );

--- a/tests/freezer-spec.js
+++ b/tests/freezer-spec.js
@@ -139,6 +139,19 @@ describe("Freezer test", function(){
 		assert.equal( second.c, data.c );
 		assert.equal( second.b.y, data.b.y );
 	});
+	it( "reset an object node", function(){
+		var foobar = { foo: 'bar', bar: 'foo' };
+		var reset = data.b.reset(foobar);
+
+		assert.deepEqual( reset, foobar );
+
+		var updated = freezer.getData().b;
+		assert.equal( reset, updated );
+
+	});
+	it( "reset is not available for array nodes", function(){
+		assert.equal( data.c.reset, undefined );
+	});
 
 	it( "Chaining calls", function(){
 		var chained = data.set( {e: 9} )
@@ -148,6 +161,7 @@ describe("Freezer test", function(){
 		var updated = freezer.getData();
 
 		assert.equal( chained, updated );
+
 	});
 
 	it( "#toJSON", function(){

--- a/tests/listener-spec.js
+++ b/tests/listener-spec.js
@@ -146,4 +146,16 @@ describe("Freezer events test", function(){
 			.set( {a: 2} )
 		;
 	});
+
+	it( "Reset of node should trigger an update", function( done ){
+		var foobar = { foo: 'bar', bar: 'foo' };
+
+		freezer.on( 'update', function(newData){
+			assert.deepEqual( newData.b, foobar );
+			done();
+		});
+
+		data.b.reset( foobar );
+	});
+
 });


### PR DESCRIPTION
- rename `replace` to `merge` in `mixin.js` and `frozen.js`
- add `reset` method as object hash method
- `reset` method is not available for arrays, added an example in `README` and also a test to show this