### PR TITLE
Make Freezer extendable (closes #22)

### DIFF
--- a/src/freezer.js
+++ b/src/freezer.js
@@ -65,7 +65,9 @@ var Freezer = function( initialValue, mutable ) {
 	this._events = [];
 }
 
-Freezer.prototype = Utils.createNonEnumerable({}, Emitter);
+Freezer.prototype = Utils.createNonEnumerable(Freezer.prototype, Emitter);
+// Restore the constructor because it's non-enumerable
+Freezer.prototype.constructor = Freezer;
 //#build
 
 module.exports = Freezer;


### PR DESCRIPTION
1) We extend `Freezer.prototype` but not replace it.
2) We have to restore non-enumerable members of `Freezer.prototype` we need.
The one is non-enumerable member of `Freezer.prototype` is `Freezer.prototype.constructor`.