### PR TITLE
support for setting value to undefined

### DIFF
--- a/src/mixins.js
+++ b/src/mixins.js
@@ -30,10 +30,10 @@ var commonMethods = {
 			update = this.__.trans
 		;
 
-		if( typeof value != 'undefined' ){
+		//if( typeof value != 'undefined' ){
 			attrs = {};
 			attrs[ attr ] = value;
-		}
+		//}
 
 		if( !update ){
 			for( var key in attrs ){


### PR DESCRIPTION
I can not find the way, how to set value to undefined using freezer. (I dont want to remove the key in hash, but set the key to undefined.)

'''javascript
parent.set("myKey",undefined);
'''
I would be able to do it with this fix. Can you please check it, that this change will not eventually break something else.

Thanks.