### PR TITLE
 Add failing test: subscribe after set triggers callback

### DIFF
--- a/tests/listener-spec.js
+++ b/tests/listener-spec.js
@@ -34,17 +34,28 @@ describe("Freezer events test", function(){
 		;
 
 		listener.on( 'update', function( data ){
-			try {
-				assert.equal( data.c, 3 );
-				assert.equal( freezer.getData().b.c, 3 );
-				done();
-			}
-			catch( e ){
-				console.log( e.stack );
-			}
+			assert.equal( data.c, 3 );
+			assert.equal( freezer.getData().b.c, 3 );
+			done();
 		});
 
 		data.b.set( {c: 3} );
+	});
+
+	it( "Subscribe after update shouldn't trigger", function( done ){
+		var listener = data.b.getListener(),
+			count = 0
+		;
+
+		data.b.set( {c: 3} );
+
+		listener.on( 'update', function( data ){
+			count++;
+		});
+
+		setTimeout(function () {
+			assert.equal( count, 0 );
+		}, 250);
 	});
 
 	it( "Listen to multiple node updates", function( done ){

--- a/tests/mutable/listener-spec.js
+++ b/tests/mutable/listener-spec.js
@@ -32,14 +32,9 @@ describe("Freezer events test", function(){
 		var listener = data.b.getListener();
 
 		listener.on( 'update', function( data ){
-			try {
-				assert.equal( data.c, 3 );
-				assert.equal( freezer.getData().b.c, 3 );
-				done();
-			}
-			catch( e ){
-				console.log( e.stack );
-			}
+			assert.equal( data.c, 3 );
+			assert.equal( freezer.getData().b.c, 3 );
+			done();
 		});
 
 		data.b.set( {c: 3} );


### PR DESCRIPTION
I think that set of triggers is determined before calling callbacks (in next animation frame) but not at calling `.set`.