### PR TITLE
Bugfix: Preserve pivot when no update is needed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,13 @@ bower_components
 
 # Users Environment Variables
 .lock-wscript
+
+#IDEs
+.idea
+
+#Mac OS
+.DS_Store
+.DS_Store?
+._*
+.Spotlight-V100
+.Trashes

--- a/src/freezer.js
+++ b/src/freezer.js
@@ -40,7 +40,7 @@ var Freezer = function( initialValue, options ) {
 				pivotTicking = 0;
 			});
 		}
-	}
+	};
 	var notify = function notify( eventName, node, options ){
 		var _ = node.__,
 			nowNode
@@ -131,7 +131,7 @@ var Freezer = function( initialValue, options ) {
 
 	// The event store
 	this._events = [];
-}
+};
 
 Freezer.prototype = Utils.createNonEnumerable({constructor: Freezer}, Emitter);
 //#build

--- a/src/mixins.js
+++ b/src/mixins.js
@@ -17,12 +17,12 @@ var createNE = function( attrs ){
 			writable: true,
 			configurable: true,
 			enumerable: false,
-			value: attrs[ key]
+			value: attrs[ key ]
 		}
 	}
 
 	return ne;
-}
+};
 
 var commonMethods = {
 	set: function( attr, value ){
@@ -42,7 +42,7 @@ var commonMethods = {
 
 			// No changes, just return the node
 			if( !update )
-				return this;
+				return Utils.findPivot( this ) || this;
 		}
 
 		return this.__.notify( 'merge', this, attrs );

--- a/tests/freezer-spec.js
+++ b/tests/freezer-spec.js
@@ -337,6 +337,25 @@ describe("Freezer test", function(){
 		assert.equal( triggered, '432143214321' );
 	});
 
+	it('Pivot should still return pivot when update is not needed', function () {
+		var freezer = new Freezer({
+			a: {
+				b: {
+					test: 1,
+					c: {
+						test: 1
+					}
+				}
+			}
+		});
+		var pivotNode = freezer.get().pivot();
+		pivotNode =
+			pivotNode
+				.set('z', 1)
+				.a.b.set('test', 1)
+				.a.b.c.set('test', 2);
 
+		assert.strictEqual(pivotNode.a.b.c.test, 2);
+	});
 
 });


### PR DESCRIPTION
**Bug:**
If using a pivot to update multiple nested objects and the call to `.set()` would not result in a change, the node is returned instead of the pivot.

**Changes:**

1. Added some stuff to the .gitignore file to prevent my IDE from polluting the repo.
2. A few minor formatting changes (added semi colons mostly) so that my editor would stop yelling at me.
3. If no update is needed in the `.set()` API, check for a pivot.  Return it if it's there and return the node if it's not.
4. Added a unit test for this use case.  Test failed due to JS error before change.  Succeeds now.