### PR TITLE
Allow to wrap objects in leafs so that they are not manipulated by freezer

### DIFF
--- a/src/freezer.js
+++ b/src/freezer.js
@@ -110,5 +110,5 @@ var Freezer = function( initialValue, options ) {
 };
 
 //#build
-
+Freezer.createLeaf = Utils.createLeaf;
 module.exports = Freezer;

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,5 +1,10 @@
 'use strict';
 
+var Leaf = function (value) {
+	this.value = value;
+	this.get = function() { return value };
+};
+
 //#build
 var global = (new Function("return this")());
 
@@ -158,7 +163,11 @@ var Utils = {
 
 	isLeaf: function( node ){
 		var cons = node && node.constructor;
-		return !cons || cons == String || cons == Number || cons == Boolean;
+		return !cons || cons == String || cons == Number || cons == Boolean || cons == Leaf;
+	},
+
+	createLeaf: function( value ) {
+		return new Leaf(value);
 	}
 };
 //#build

--- a/tests/freezer-spec.js
+++ b/tests/freezer-spec.js
@@ -11,7 +11,8 @@ var example = {
 	a: 1,
 	b: { z: 0, y: 1, x:[ 'A', 'B'] },
 	c: [1, 2, {w: 3}],
-	d: null
+	d: null,
+	e: Freezer.createLeaf({ objProp: true })
 };
 
 describe("Freezer test", function(){
@@ -27,12 +28,15 @@ describe("Freezer test", function(){
 		assert.equal( data.c[0], example.c[0] );
 		assert.equal( data.c[2].w, example.c[2].w );
 		assert.equal( data.d, example.d);
+		assert.equal( data.e.get(), example.e.get());
 	});
 
 	it( "Leaves dont have an __", function(){
 		assert.equal( data.a.__, undefined );
 		assert.equal( data.b.z.__, undefined );
 		assert.equal( data.c[1].__, undefined );
+		assert.equal( data.e.__, undefined );
+		assert.equal( data.e.get().__, undefined );
 	});
 
 	it( "Reset with a previous state", function( done ){
@@ -268,7 +272,8 @@ describe("Freezer test", function(){
 		var second = freezer.getData();
 
 		assert.equal( second, data );
-		assert.equal( second.e, undefined );
+		assert.equal( second.e.get(), data.e.get() );
+		assert.equal( second.f, undefined );
 		assert.equal( second.c, data.c );
 		assert.equal( second.b.y, data.b.y );
 	});


### PR DESCRIPTION
This PR adds the possibility to wrap objects in a "Leaf", which is guaranteed to be not manipulated by freezer. This is useful when handling with native objects or functions which should remain intact and untouched (see #81). Accessing the content of a leaf can be done via a simple `get` method.

```js
var example = {
	e: Freezer.createLeaf({ func: function() { return true; } })
};
freezer = new Freezer( example );
var unwrappedLeaf = freezer.getData().e.get();
unwrappedLeaf.func() === true;
```

This change is just a suggestion. I'm happy to discuss a different interface/solution.