### PR TITLE
Fix fixChildren issue that leave parents of deeper child unchanged

### DIFF
--- a/src/frozen.js
+++ b/src/frozen.js
@@ -333,14 +333,10 @@ var Frozen = {
 			if( !child || !child.__ )
 				return;
 
-			// If the child is linked to the node,
-			// maybe its children are not linked
-			if( child.__.parents.indexOf( node ) != -1 )
-				return me.fixChildren( child );
+			// Update parents in all children no matter the child
+			// is linked to the node or not.
+			me.fixChildren( child );
 
-			// If the child wasn't linked it is sure
-			// that it wasn't modified. Just link it
-			// to the new parent
 			if( child.__.parents.length == 1 )
 				return child.__.parents = [ node ];
 


### PR DESCRIPTION
## Symptom

![image](https://cloud.githubusercontent.com/assets/491380/18934664/86149638-8637-11e6-8f79-fe2a49bb3d2d.png)

## Cause

fixChildren leave the parents of deeper child unchanged in some cases.

## Changed

Update parents of all children during reset.