### PR TITLE
Make Freezer usable with strict Content Security Policy

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -1,13 +1,13 @@
 'use strict';
 
 //#build
-var global = typeof global !== 'undefined' ? 
-             global : 
-             typeof self !== 'undefined' ? 
-               self : 
-               typeof window !== 'undefined' ?
-               window :
-               {};
+var global = typeof global !== 'undefined' ?
+	global :
+	typeof self !== 'undefined' ?
+		self :
+		typeof window !== 'undefined' ?
+			window :
+			{};
 
 var Utils = {
 	extend: function( ob, props ){

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,7 +1,13 @@
 'use strict';
 
 //#build
-var global = (new Function("return this")());
+var global = typeof global !== 'undefined' ? 
+             global : 
+             typeof self !== 'undefined' ? 
+               self : 
+               typeof window !== 'undefined' ?
+               window :
+               {};
 
 var Utils = {
 	extend: function( ob, props ){


### PR DESCRIPTION
Hi there,

This is a small PR to ensure Freezer can be used with a strict Content Security Policy. At present, it cannot, because of a [line in utils.js](https://github.com/arqex/freezer/blob/3da2610c5e07eed52d7886c9906b808081559ff6/src/utils.js#L4) that evals a string: `var global = (new Function("return this")());`.

I fixed this by replacing the line with the same functionality as used by Browserify:
```
var global = typeof global !== 'undefined' ? 
             global : 
             typeof self !== 'undefined' ? 
               self : 
               typeof window !== 'undefined' ?
               window :
               {};
```

For background, you can read a detailed discussion of how to get the global Javascript object here:
https://www.contentful.com/blog/2017/01/17/the-global-object-in-javascript/

And browserify's use of this approach is here:
https://github.com/substack/insert-module-globals/blob/769f4bd08e01b77a620f2e2de1d2249c8311b0a2/index.js#L30

Many thanks for such a beautiful library!

Greg



