### PR TITLE
Added Single Parent Flag

### DIFF
--- a/src/freezer.js
+++ b/src/freezer.js
@@ -11,7 +11,8 @@ var Freezer = function( initialValue, options ) {
 		ops = options || {},
 		store = {
 			live: ops.live || false,
-			freezeInstances: ops.freezeInstances || false
+			freezeInstances: ops.freezeInstances || false,
+			singleParent: ops.singleParent || false
 		}
 	;
 

--- a/src/frozen.js
+++ b/src/frozen.js
@@ -403,6 +403,9 @@ var Frozen = {
 		;
 
 		if( index === -1 ){
+			if(node.__.store.singleParent && parents.length >= 1){
+				throw new Error('Node already has a parent');
+			}
 			parents[ parents.length ] = parent;
 		}
 	},

--- a/tests/freezer-spec.js
+++ b/tests/freezer-spec.js
@@ -434,4 +434,17 @@ describe("Freezer test", function(){
 		assert.equal( freezer.get().b.z, 0 );
 		assert.equal( freezer.get().b.x[0], 'z' );
 	});
+
+	it('singleParent should limit a node to having one parent', function () {
+		var freezer = new Freezer({
+			a: {
+				b: {}
+			},
+			c: {}
+		}, {singleParent: true, live: true});
+		const oldB = freezer.get().a.b;
+		assert.throws(function() {
+			freezer.get().c.set({b: oldB});
+		}, Error, "Node already has a parent");
+	});
 });


### PR DESCRIPTION
This PR attempts to address Issue #103. I've added a ```singleParent``` flag to the Freezer constructor that makes the ```addParent``` function throw an exception if a node is about to get multiple parents. The default for the flag is ```false```, so no existing code should be effected. 



